### PR TITLE
Route homepage to booking index

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :bookings
+
+  root 'bookings#index'
 end


### PR DESCRIPTION
Initially, `localhost:3000` routes you to the default Rails landing page "Yay! You're on rails!"

`localhost:3000` now brings you to the booking index page instead of needing to go to `localhost:3000/bookings`

